### PR TITLE
✨ feat: Add WHOIS lookup + domain intelligence module

### DIFF
--- a/recon/whois_lookup.py
+++ b/recon/whois_lookup.py
@@ -1,0 +1,86 @@
+"""WHOIS lookup and domain intelligence gathering."""
+import socket
+import re
+from typing import Dict, Optional
+
+
+WHOIS_SERVERS = {
+    "com": "whois.verisign-grs.com",
+    "net": "whois.verisign-grs.com",
+    "org": "whois.pir.org",
+    "io":  "whois.iana.org",
+    "co":  "whois.iana.org",
+    "dev": "whois.nic.google",
+    "app": "whois.nic.google",
+    "ai":  "whois.iana.org",
+    "_default": "whois.iana.org",
+}
+
+
+def _get_whois_server(domain: str) -> str:
+    tld = domain.rsplit(".", 1)[-1].lower()
+    return WHOIS_SERVERS.get(tld, WHOIS_SERVERS["_default"])
+
+
+def raw_whois(domain: str, timeout: int = 10) -> str:
+    """Query the WHOIS server and return raw response."""
+    server = _get_whois_server(domain)
+    try:
+        with socket.create_connection((server, 43), timeout=timeout) as sock:
+            sock.sendall((domain + "\r\n").encode())
+            response = b""
+            while True:
+                data = sock.recv(4096)
+                if not data:
+                    break
+                response += data
+        return response.decode("utf-8", errors="ignore")
+    except (socket.timeout, socket.error) as e:
+        return f"WHOIS query failed: {e}"
+
+
+def parse_whois(raw: str) -> Dict:
+    """Parse raw WHOIS output into a structured dict."""
+    fields = {
+        "registrar":       r"Registrar:\s*(.+)",
+        "created":         r"Creation Date:\s*(.+)",
+        "expires":         r"Registry Expiry Date:\s*(.+)",
+        "updated":         r"Updated Date:\s*(.+)",
+        "name_servers":    r"Name Server:\s*(.+)",
+        "status":          r"Domain Status:\s*(.+)",
+        "registrant_org":  r"Registrant Organization:\s*(.+)",
+        "registrant_country": r"Registrant Country:\s*(.+)",
+        "emails":          r"[\w.+-]+@[\w.-]+\.[a-zA-Z]{2,}",
+    }
+
+    result: Dict = {}
+    for key, pattern in fields.items():
+        if key == "name_servers":
+            matches = re.findall(pattern, raw, re.IGNORECASE)
+            result[key] = list(set(m.strip().lower() for m in matches)) if matches else []
+        elif key == "emails":
+            matches = re.findall(pattern, raw)
+            result[key] = list(set(matches)) if matches else []
+        else:
+            match = re.search(pattern, raw, re.IGNORECASE)
+            result[key] = match.group(1).strip() if match else None
+
+    return result
+
+
+def lookup(domain: str, timeout: int = 10) -> Dict:
+    """
+    Perform WHOIS lookup and return parsed results.
+
+    Args:
+        domain: Target domain (e.g. example.com)
+        timeout: Socket timeout in seconds
+
+    Returns:
+        Dict with registrar, dates, name servers, emails, etc.
+    """
+    raw = raw_whois(domain, timeout)
+    parsed = parse_whois(raw)
+    parsed["domain"] = domain
+    parsed["raw"] = raw
+    return parsed

--- a/tests/test_whois.py
+++ b/tests/test_whois.py
@@ -1,0 +1,50 @@
+"""Tests for WHOIS lookup module."""
+import pytest
+from unittest.mock import patch, MagicMock
+from recon.whois_lookup import _get_whois_server, parse_whois, WHOIS_SERVERS
+
+
+def test_get_whois_server_com():
+    assert _get_whois_server("example.com") == WHOIS_SERVERS["com"]
+
+
+def test_get_whois_server_org():
+    assert _get_whois_server("example.org") == WHOIS_SERVERS["org"]
+
+
+def test_get_whois_server_unknown_tld():
+    server = _get_whois_server("example.xyz")
+    assert server == WHOIS_SERVERS["_default"]
+
+
+def test_parse_whois_registrar():
+    raw = """
+Domain Name: EXAMPLE.COM
+Registrar: GoDaddy.com, LLC
+Creation Date: 2020-01-01T00:00:00Z
+Registry Expiry Date: 2030-01-01T00:00:00Z
+Name Server: NS1.GODADDY.COM
+Name Server: NS2.GODADDY.COM
+Registrant Organization: Example Inc
+Registrant Country: US
+admin@example.com
+"""
+    result = parse_whois(raw)
+    assert result["registrar"] == "GoDaddy.com, LLC"
+    assert result["registrant_country"] == "US"
+    assert "ns1.godaddy.com" in result["name_servers"]
+    assert any("@example.com" in e for e in result["emails"])
+
+
+def test_parse_whois_empty():
+    result = parse_whois("")
+    assert result["registrar"] is None
+    assert result["name_servers"] == []
+    assert result["emails"] == []
+
+
+def test_parse_whois_no_emails():
+    raw = "Domain Name: EXAMPLE.COM\nRegistrar: Test Registrar\n"
+    result = parse_whois(raw)
+    assert result["emails"] == []
+    assert result["registrar"] == "Test Registrar"


### PR DESCRIPTION
## Summary

Adds `recon/whois_lookup.py` with:

- **Raw WHOIS query** — connects to the correct WHOIS server per TLD
- **Structured parsing** — extracts registrar, creation/expiry dates, name servers, emails, registrant country
- **Domain intelligence** — returns full parsed dict for downstream processing

## Tests
6 new pytest tests — all passing ✅

## Usage
```python
from recon.whois_lookup import lookup
result = lookup("example.com")
print(result["registrar"])  # GoDaddy.com, LLC
print(result["emails"])     # Admin emails found
```